### PR TITLE
[Fix] add bin parameter to package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "rebuild-debug": "node-gyp -j 16 rebuild --debug",
     "test": "mocha -r chai test/**/test-*.js"
   },
+  "bin": "./bin/node-ios-device",
   "dependencies": {
     "cli-kit": "^0.11.1",
     "napi-macros": "^2.0.0",


### PR DESCRIPTION
In order to let user call node-ios-device in the shell, you have to add "bin" and specify path in the package.json.

I have tested in the local by calling `$npm link` and `$node-ios-device` in the shell.