### PR TITLE
fix: include new PrivateFrameworks path

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -42,6 +42,11 @@
 					'cflags_cc!': [
 						'-fno-exceptions'
 					],
+					'variables': {
+						'build_v8_with_gn': 'false',
+						'v8_enable_pointer_compression': 'false',
+						'v8_enable_31bit_smis_on_64bit_arch': 'false'
+					},
 					'xcode_settings': {
 						'OTHER_CPLUSPLUSFLAGS' : [ '-std=c++17', '-stdlib=libc++' ],
 						'OTHER_LDFLAGS': [ '-stdlib=libc++' ],

--- a/binding.gyp
+++ b/binding.gyp
@@ -26,7 +26,9 @@
 						'MobileDevice.framework'
 					],
 					'mac_framework_dirs': [
-						'<(module_root_dir)/build'
+						'<(module_root_dir)/build',
+						'/System/Library/PrivateFrameworks',
+						'/Library/Apple/System/Library/PrivateFrameworks'
 					],
 					'include_dirs': [
 						'<!(node -e "require(\'napi-macros\')")'
@@ -39,14 +41,6 @@
 					],
 					'cflags_cc!': [
 						'-fno-exceptions'
-					],
-					'actions': [
-						{
-							'action_name': 'copy_mobiledevice',
-							'inputs': [ '/System/Library/PrivateFrameworks/MobileDevice.framework' ],
-							'outputs': [ '<(module_root_dir)/build/MobileDevice.framework' ],
-							'action': [ 'cp', '-R', '<@(_inputs)', '<@(_outputs)' ]
-						}
 					],
 					'xcode_settings': {
 						'OTHER_CPLUSPLUSFLAGS' : [ '-std=c++17', '-stdlib=libc++' ],


### PR DESCRIPTION
- Remove unnecessary `MobileDevice.framework` copy
- Include new `PrivateFrameworks` path for Catalina

##### NOTE: Not sure if you also want this in `v2` branch?