### PR TITLE
build: add back copying of MobileDevice framework

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,11 @@
 #! groovy
-/*
+
 library 'pipeline-library'
 
 buildNPMPackage {
-  labels = 'osx && git && npm-publish && xcode-9'
+  labels = 'osx && git && npm-publish && xcode'
   downstream = ['../appc-cli']
   projectKey = 'TIMOB'
   npmVersion = '1.7.0' // this is actually the yarn version to use, could be set to 'latest' instead of explicit version too
 }
-*/
+

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,4 +1,8 @@
 {
+	'variables': {
+		'mobiledevice_framework_location': '/System/Library/PrivateFrameworks/MobileDevice.framework',
+		'new_mobiledevice_framework_location': '/Library/Apple/System/Library/PrivateFrameworks/MobileDevice.framework'
+	},
 	'conditions': [
 		['OS=="mac"', {
 			'targets': [
@@ -40,20 +44,22 @@
 					'cflags_cc!': [
 						'-fno-exceptions'
 					],
-					'actions': [
-						{
-							'action_name': 'copy_mobiledevice',
-							'inputs': [ '/System/Library/PrivateFrameworks/MobileDevice.framework' ],
-							'outputs': [ '<(module_root_dir)/build/MobileDevice.framework' ],
-							'action': [ 'cp', '-R', '<@(_inputs)', '<@(_outputs)' ]
-						}
-					],
 					'xcode_settings': {
 						'OTHER_CPLUSPLUSFLAGS' : [ '-std=c++17', '-stdlib=libc++' ],
 						'OTHER_LDFLAGS': [ '-stdlib=libc++' ],
 						'MACOSX_DEPLOYMENT_TARGET': '10.11',
 						'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
-					}
+					},
+					'actions': [
+						{
+							'action_name': 'copy_mobiledevice',
+							'inputs': [ ],
+							'outputs': [ '<(module_root_dir)/build/' ],
+							'action': [ 
+								'./copy-framework.sh', '<@(mobiledevice_framework_location)', '<@(new_mobiledevice_framework_location)', '<@(_outputs)'
+							 ]
+						}
+					]
 				}
 			]
 		}, {

--- a/copy-framework.sh
+++ b/copy-framework.sh
@@ -1,0 +1,24 @@
+# MobileDevice.framework can live in two locations, the first is blocked from being accessed when
+# building so we need to copy it to our build directory to ensure that we can use it during the
+# build process. The second location is seemingly for updated versions of the framework and the
+# first location will actually become a symlink to this destination if it exists.
+
+MOBILEDEVICE_LOCATION=$1
+MOBILEDEVICE_NEW_LOCATION=$2
+BUILD_DIRECTORY=$3
+MOBILEDEVICE_TO_COPY=""
+
+if [ -d $MOBILEDEVICE_LOCATION ]; then
+    MOBILEDEVICE_TO_COPY=$MOBILEDEVICE_LOCATION
+fi
+
+if [ -d $MOBILEDEVICE_NEW_LOCATION ]; then
+    MOBILEDEVICE_TO_COPY=$MOBILEDEVICE_NEW_LOCATION
+fi
+
+if [ -z "$MOBILEDEVICE_TO_COPY" ]; then
+    echo "Could not find MobileDevice.framework"
+    exit 1
+else
+    cp -RL $MOBILEDEVICE_TO_COPY $BUILD_DIRECTORY
+fi


### PR DESCRIPTION
The MobileDevice framework can live in two locations. From Xcode 9 the first location is blocked
from being linked to which will cause build failures, the second location is not blocked  but only
seems to exist in specific circumstances (current theory is that it is where updated versions are)
placed. This fixes the build process so that we copy the framework to the build directory from one
of those locations allowing us to link against it with no issues.