### PR TITLE
feat: support node 16

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -42,8 +42,6 @@
 						'-fno-exceptions'
 					],
 					'xcode_settings': {
-						'OTHER_CPLUSPLUSFLAGS' : [ '-std=c++11', '-stdlib=libc++' ],
-						'OTHER_LDFLAGS': [ '-stdlib=libc++' ],
 						'MACOSX_DEPLOYMENT_TARGET': '10.11',
 						'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
 					},

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "devices"
   ],
   "dependencies": {
-    "@mapbox/node-pre-gyp": "^1.0.1",
+    "@mapbox/node-pre-gyp": "^1.0.4",
     "debug": "^4.2.0",
     "nan": "^2.14.2",
     "node-pre-gyp-init": "^1.2.0"
@@ -58,7 +58,8 @@
       "12.11.0": 72,
       "13.5.0": 79,
       "14.13.1": 83,
-      "15.0.1": 88
+      "15.0.1": 88,
+      "16.0.0": 93
     }
   },
   "license": "Apache-2.0",

--- a/src/node-ios-device.cpp
+++ b/src/node-ios-device.cpp
@@ -355,7 +355,12 @@ NAN_MODULE_INIT(init) {
 	Nan::Set(target, Nan::New("startLogRelay").ToLocalChecked(), Nan::GetFunction(Nan::New<FunctionTemplate>(startLogRelay)).ToLocalChecked());
 	Nan::Set(target, Nan::New("stopLogRelay").ToLocalChecked(),  Nan::GetFunction(Nan::New<FunctionTemplate>(stopLogRelay)).ToLocalChecked());
 
+#if NODE_MAJOR_VERSION >= 12
+	node::Environment* env = node::GetCurrentEnvironment(Nan::GetCurrentContext());
+	node::AtExit(env, cleanup, NULL);
+#else
 	node::AtExit(cleanup);
+#endif
 }
 
 NODE_MODULE(node_ios_device, init)

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,6 +17,21 @@
     semver "^7.3.4"
     tar "^6.1.0"
 
+"@mapbox/node-pre-gyp@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.4.tgz#6c76e7a40138eac39e1a4dc869a083e43e236c00"
+  integrity sha512-M669Qo4nRT7iDmQEjQYC7RU8Z6dpz9UmSbkJ1OFEja3uevCdLKh7IZZki7L1TZj02kRyl82snXFY8QqkyfowrQ==
+  dependencies:
+    detect-libc "^1.0.3"
+    https-proxy-agent "^5.0.0"
+    make-dir "^3.1.0"
+    node-fetch "^2.6.1"
+    nopt "^5.0.0"
+    npmlog "^4.1.2"
+    rimraf "^3.0.2"
+    semver "^7.3.4"
+    tar "^6.1.0"
+
 "@octokit/auth-token@^2.4.4":
   version "2.4.5"
   resolved "https://registry.yarnpkg.com/@octokit/auth-token/-/auth-token-2.4.5.tgz#568ccfb8cb46f36441fac094ce34f7a875b197f3"
@@ -281,6 +296,14 @@ http-proxy-agent@^4.0.1:
   integrity sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==
   dependencies:
     "@tootallnate/once" "1"
+    agent-base "6"
+    debug "4"
+
+https-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
+  integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
+  dependencies:
     agent-base "6"
     debug "4"
 


### PR DESCRIPTION
This adds support for Node.js 16, I also tested the changes made against 12.13.0, 12.22.0, and 14.6.1.

In summary:

* Bump to latest node-pre-gyp
* Remove setting of c++11 stdlib due to V8/Node.js now requiring c++14
* Updates the usage of AtExit due to compile error on 16
	* This has been a warning since 13.5.0/12.15.0 [it appears](https://github.com/nodejs/node/pull/30227), and the API has supported 3 arguments [since 8.0.0](https://github.com/nodejs/node/pull/9163). The version check could potentially be removed in favour of always calling with 3 args
	* As stated in that PR, using `AddEnvironmentCleanupHook` is preferred, but I figured it was best to stick with whats there already