### PR TITLE
build: build arm64 alongside x86_64

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ library 'pipeline-library'
 def canPublish = env.BRANCH_NAME == '1_X'
 
 buildNPMPackage {
-  labels = 'osx && git && npm-publish && xcode'
+  labels = 'osx && git && npm-publish && xcode-12'
   downstream = ['../appc-cli']
   projectKey = 'TIMOB'
   npmVersion = '1.7.0' // this is actually the yarn version to use, could be set to 'latest' instead of explicit version too

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,8 +4,7 @@ library 'pipeline-library'
 def canPublish = env.BRANCH_NAME == '1_X'
 
 buildNPMPackage {
-  labels = 'osx && git && npm-publish && xcode-12'
-  downstream = ['../appc-cli']
+  labels = 'osx-11 && git && npm-publish'
   projectKey = 'TIMOB'
   npmVersion = '1.7.0' // this is actually the yarn version to use, could be set to 'latest' instead of explicit version too
   artifacts = 'binding/**/*'

--- a/bin/build-all.js
+++ b/bin/build-all.js
@@ -10,6 +10,7 @@ const path = require('path');
 const pkgJson = require(path.resolve(__dirname + '/../package.json'));
 const targets = Object.keys(pkgJson.binary.targets);
 const nodePreGyp = path.resolve(__dirname, '..', 'node_modules/.bin/node-pre-gyp');
+const archs = ['x86_64', 'arm64'];
 let actions = process.argv.slice(2); // pass in args for what to do
 
 let isPublish = false;
@@ -43,12 +44,14 @@ const spawnSync = require('child_process').spawnSync;
 let exitCode = 0;
 actions.forEach(action => {
 	targets.forEach(target => {
-		const args = [ nodePreGyp ].concat('--target=' + target, action);
-		console.log('Executing:', process.execPath, args.join(' '));
-		const result = spawnSync(process.execPath, args, { stdio: 'inherit' });
-		if (result.status) {
-			exitCode = 1;
-		}
+		archs.forEach(arch => {
+			const args = [ nodePreGyp ].concat('--target=' + target, '--target_arch=' + arch, action);
+			console.log('Executing:', process.execPath, args.join(' '));
+			const result = spawnSync(process.execPath, args, { stdio: 'inherit' });
+			if (result.status) {
+				exitCode = 1;
+			}
+		});
 	});
 });
 


### PR DESCRIPTION
This adds building arm64 variants to the existing x86_64 variants. I _think_ this is all that's required as there doesn't seem to be any knowledge of architecture in the scripts so far. 

I do have a small suspicion that this _might_ fail to build on either older Xcode version or possibly even older mac versions (i.e. older than Big Sur), but I don't have anything older to test unfortunately 